### PR TITLE
Download via rawpixelsstore

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,12 @@ $ omero zarr Image:1 --output /home/user/zarr_files
 
 ```
 
-To export images via bioformats2raw:
+To export images via bioformats2raw we use the ```--bf``` flag:
 
 ```
 export MANAGED_REPO=/var/omero/data/ManagedRepository
 export BF2RAW=/opt/tools/bioformats2raw-0.2.0-SNAPSHOT
 
-$ omero zarr 1 --output /home/user/zarr_files
+$ omero zarr 1 --bf --output /home/user/zarr_files
 Image exported to /home/user/zarr_files/2chZT.lsm
 ```

--- a/README.md
+++ b/README.md
@@ -1,13 +1,44 @@
 OMERO CLI Zarr plugin
 =====================
 
-Example usage:
+This OMERO command-line plugin allows you to export images from
+OMERO as zarr files, according to the spec at 
+https://github.com/ome/omero-ms-zarr/blob/master/spec.md.
+
+It supports export using 2 alternative methods:
+
+- By default the OMERO API is used to load planes as numpy arrays
+  and the zarr file is created from this data. NB: currently, large
+  tiled images are not supported by this method.
+
+- Alternatively, if you can read directly from the OMERO binary
+  repository and have installed https://github.com/glencoesoftware/bioformats2raw
+  then you can use this to create zarr files.
+
+
+# Usage
+
+To export images via the OMERO API:
+
+```
+# Image will be saved in current directory as 1.zarr
+$ omero zarr Image:1
+
+# Specify an output directory
+$ omero zarr Image:1 --output /home/user/zarr_files
+
+# Cache each plane as a numpy file.npy. If connection is lost, and you need
+# to export again, we can use these instead of downloading again
+# omero zarr Image:1 --cache_numpy
+
+```
+
+To export images via bioformats2raw:
+
 ```
 export MANAGED_REPO=/var/omero/data/ManagedRepository
 export BF2RAW=/opt/tools/bioformats2raw-0.2.0-SNAPSHOT
 
-# Export image with ID 1
-> omero zarr 1 /home/user/zarr_files
-Using session for root@localhost:4064. Idle timeout: 10 min. Current group: system
+$ omero zarr 1 --output /home/user/zarr_files
 Image exported to /home/user/zarr_files/2chZT.lsm
 ```

--- a/src/omero_cli_zarr.py
+++ b/src/omero_cli_zarr.py
@@ -7,8 +7,12 @@ from functools import wraps
 import omero
 from omero.cli import BaseControl
 from omero.cli import CLI
+from omero.cli import ProxyStringType
 from omero.gateway import BlitzGateway
 from omero.rtypes import rlong
+from omero.model import ImageI
+
+from raw_pixels import image_to_zarr
 
 HELP = "Export an image in zarr format."
 
@@ -41,25 +45,52 @@ class ZarrControl(BaseControl):
   def _configure(self, parser):
     parser.add_login_arguments()
 
-    parser.add_argument("image_id", type=int, help="The Image to export")
-    parser.add_argument("target", type=str, help="The target directory")
+    ProxyStringType("Image")
+    parser.add_argument("object", type=ProxyStringType("Image"),
+      help="The Image to export.")
+    parser.add_argument("--target", type=str, default="", help="The target directory")
 
-    parser.add_argument("--tile_width", default=None)
-    parser.add_argument("--tile_height", default=None)
-    parser.add_argument("--resolutions", default=None)
-    parser.add_argument("--max_workers", default=None)
+    parser.add_argument(
+      "--cache_numpy", action="store_true",
+      help="Save planes as .npy files in case of connection loss")
+
+    parser.add_argument("--bf", action="store_true",
+                        help="Use bioformats2raw to read from managed repo")
+    parser.add_argument("--tile_width", default=None,
+                        help="For use with bioformats2raw")
+    parser.add_argument("--tile_height", default=None,
+                        help="For use with bioformats2raw")
+    parser.add_argument("--resolutions", default=None,
+                        help="For use with bioformats2raw")
+    parser.add_argument("--max_workers", default=None,
+                        help="For use with bioformats2raw")
 
     parser.set_defaults(func=self.export)
 
   @gateway_required
   def export(self, args):
-    path, name = self._get_path(args.image_id)
 
-    if path:
-      self._do_export(path, name, args)
-    else:
-      print("Couldn't find managed repository path for this image.")
+    if isinstance(args.object, ImageI):
+      image_id = args.object.id
+      image = self._lookup(self.gateway, "Image", image_id)
+      self.ctx.out("Export image: %s" % image.name)
 
+      if args.bf:
+        path, name = self._get_path(image_id)
+        if path:
+          self._do_export(path, name, args)
+        else:
+          print("Couldn't find managed repository path for this image.")
+      else:
+        image_to_zarr(image, args)
+
+  def _lookup(self, gateway, type, oid):
+        """Find object of type by ID."""
+        gateway.SERVICE_OPTS.setOmeroGroup("-1")
+        obj = gateway.getObject(type, oid)
+        if not obj:
+            self.ctx.die(110, "No such %s: %s" % (type, oid))
+        return obj
 
   def _do_export(self, path, name, args):
     abs_path = Path(os.environ['MANAGED_REPO']) / path / name

--- a/src/omero_cli_zarr.py
+++ b/src/omero_cli_zarr.py
@@ -48,7 +48,7 @@ class ZarrControl(BaseControl):
     ProxyStringType("Image")
     parser.add_argument("object", type=ProxyStringType("Image"),
       help="The Image to export.")
-    parser.add_argument("--target", type=str, default="", help="The target directory")
+    parser.add_argument("--output", type=str, default="", help="The output directory")
 
     parser.add_argument(
       "--cache_numpy", action="store_true",
@@ -97,7 +97,7 @@ class ZarrControl(BaseControl):
 
     bf2raw = Path(os.environ['BF2RAW'])
 
-    target = Path(args.target) / name
+    target = Path(args.output) / name
     target.mkdir(exist_ok=True)
 
     options = "--file_type=zarr"

--- a/src/raw_pixels.py
+++ b/src/raw_pixels.py
@@ -1,0 +1,110 @@
+
+import argparse
+import sys
+import os
+
+import omero.clients
+from omero.rtypes import unwrap
+import numpy
+import zarr
+
+# Uses CLI login to load Image from OMERO and save as zarr:
+
+# $ python omero_to_zarr.py 123
+# will create 123.zarr
+
+def image_to_zarr(image, args):
+
+    cache_numpy = args.cache_numpy
+    target_dir = args.target
+
+    size_c = image.getSizeC()
+    size_z = image.getSizeZ()
+    size_x = image.getSizeX()
+    size_y = image.getSizeY()
+    size_t = image.getSizeT()
+
+    # dir for caching .npy planes
+    if cache_numpy:
+        os.makedirs(os.path.join(target_dir, str(image.id)), mode=511, exist_ok=True)
+    name = os.path.join(target_dir, '%s.zarr' % image.id)
+    za = None
+    pixels = image.getPrimaryPixels()
+
+    zct_list = []
+    for t in range(size_t):
+        for c in range(size_c):
+            for z in range(size_z):
+                # We only want to load from server if not cached locally
+                filename = os.path.join(
+                    target_dir, str(image.id),
+                    '{:03d}-{:03d}-{:03d}.npy'.format(z, c, t))
+                if not os.path.exists(filename):
+                    zct_list.append( (z,c,t) )
+
+    def planeGen():
+        planes = pixels.getPlanes(zct_list)
+        for p in planes:
+            yield p
+
+    planes = planeGen()
+
+    for t in range(size_t):
+        for c in range(size_c):
+            for z in range(size_z):
+                filename = os.path.join(
+                    target_dir, str(image.id),
+                    '{:03d}-{:03d}-{:03d}.npy'.format(z, c, t))
+                if os.path.exists(filename):
+                    print(f'plane (from disk) c:{c}, t:{t}, z:{z}')
+                    plane = numpy.load(filename)
+                else:
+                    print(f'loading plane c:{c}, t:{t}, z:{z}')
+                    plane = next(planes)
+                    if cache_numpy:
+                        print(f'cached at {filename}')
+                        numpy.save(filename, plane)
+                if za is None:
+                    # store = zarr.NestedDirectoryStore(name)
+                    # root = zarr.group(store=store, overwrite=True)
+                    root = zarr.open_group(name, mode='w')
+                    za = root.create(
+                        '0',
+                        shape=(size_t, size_c, size_z, size_y, size_x),
+                        chunks=(1, 1, 1, size_y, size_x),
+                        dtype=plane.dtype
+                    )
+                za[t, c, z, :, :] = plane
+        add_group_metadata(root, image)
+    print("Created", name)
+
+
+def add_group_metadata(zarr_root, image, resolutions=1):
+
+    image_data = {
+        'id': 1,
+        'channels': [channelMarshal(c) for c in image.getChannels()],
+        'rdefs': {'model': (image.isGreyscaleRenderingModel() and
+                                     'greyscale' or 'color'),
+                           'defaultZ': image._re.getDefaultZ(),
+                           'defaultT': image._re.getDefaultT()}
+    }
+    multiscales = [{
+        "version": "0.1",
+        "datasets": [{'path': str(r)} for r in range(resolutions)],
+    }]
+    zarr_root.attrs["multiscales"] = multiscales
+    zarr_root.attrs["omero"] = image_data
+
+
+def channelMarshal(channel):
+    return {'label': channel.getLabel(),
+            'color': channel.getColor().getHtml(),
+            'inverted': channel.isInverted(),
+            'family': unwrap(channel.getFamily()),
+            'coefficient': unwrap(channel.getCoefficient()),
+            'window': {'min': channel.getWindowMin(),
+                       'max': channel.getWindowMax(),
+                       'start': channel.getWindowStart(),
+                       'end': channel.getWindowEnd()},
+            'active': channel.isActive()}

--- a/src/raw_pixels.py
+++ b/src/raw_pixels.py
@@ -8,15 +8,11 @@ from omero.rtypes import unwrap
 import numpy
 import zarr
 
-# Uses CLI login to load Image from OMERO and save as zarr:
-
-# $ python omero_to_zarr.py 123
-# will create 123.zarr
 
 def image_to_zarr(image, args):
 
     cache_numpy = args.cache_numpy
-    target_dir = args.target
+    target_dir = args.output
 
     size_c = image.getSizeC()
     size_z = image.getSizeZ()


### PR DESCRIPTION
Ported the script from https://github.com/ome/omero-ms-zarr/blob/master/src/scripts/omero_to_zarr.py and updated with omero metadata

To test:

```
$ omero zarr Image:1 --output test
...
Created test/1.zarr
```
Also test the other arguments mentioned in the README (```--output``` and ```--cache_numpy```).

Use napari and the https://github.com/ome/ome-zarr-py to open in napari:
```
$ napari test/1.zarr
```

To export with bioformats2raw, use the ```--bf``` flag.