### PR TITLE
Export masks as 4D zarr

### DIFF
--- a/src/masks.py
+++ b/src/masks.py
@@ -81,8 +81,6 @@ def masks_to_zarr(masks, image):
             # ADD to the array, so zeros in our binarray don't wipe out previous masks
             labels[t, z, y:(y+h), x:(x+w)] += (binarray * (count))
 
-    print(labels)
-    print(labels.min(), labels.max())
     return labels
 
 

--- a/src/masks.py
+++ b/src/masks.py
@@ -1,0 +1,104 @@
+
+import argparse
+import sys
+import os
+
+import omero.clients
+from omero.model import MaskI
+from omero.rtypes import unwrap
+import numpy as np
+import zarr
+
+
+def image_masks_to_zarr(image, args):
+
+    target_dir = args.output
+
+    size_c = image.getSizeC()
+    size_z = image.getSizeZ()
+    size_x = image.getSizeX()
+    size_y = image.getSizeY()
+    size_t = image.getSizeT()
+
+    conn = image._conn
+    roi_service = conn.getRoiService()
+    result = roi_service.findByImage(image.id, None)
+
+    masks = {}
+    for roi in result.rois:
+        mask_shapes = []
+        for s in roi.copyShapes():
+            if isinstance(s, MaskI):
+                mask_shapes.append(s)
+
+        if len(mask_shapes) > 0:
+            masks[roi.id.val] = mask_shapes
+
+    print(f'Found {len(masks)} masks')
+
+    if masks:
+        stack = masks_to_zarr(masks, image)
+        name = f'{image.id}_masks.zarr'
+        root = zarr.open_group(name, mode='w')
+        za = root.create(
+            '0',
+            shape=stack.shape,
+            chunks=(1, 1, size_y, size_x),
+            dtype=stack.dtype
+        )
+
+        za[:, :, :, :] = stack
+
+        print("Created", name)
+    else:
+        print("No masks found on Image")
+
+
+def masks_to_zarr(masks, image):
+
+    # Create np nd-array same size as image
+    size_t = image.getSizeT()
+    size_z = image.getSizeZ()
+    size_x = image.getSizeX()
+    size_y = image.getSizeY()
+
+    labels = np.zeros((size_t, size_z, size_y, size_x))
+    for count, shapes in enumerate(masks.values()):
+        # All shapes same color for each ROI
+        for mask in shapes:
+            t = unwrap(mask.theT) or 0
+            z = unwrap(mask.theZ) or 0
+            x = int(mask.x.val)
+            y = int(mask.y.val)
+            w = int(mask.width.val)
+            h = int(mask.height.val)
+            mask_packed = mask.getBytes()
+            # convert bytearray into something we can use
+            intarray = np.fromstring(mask_packed, dtype=np.uint8)
+            binarray = np.unpackbits(intarray)
+            # truncate and reshape
+            binarray = np.reshape(binarray[:(w * h)], (h, w))
+            # ADD to the array, so zeros in our binarray don't wipe out previous masks
+            labels[t, z, y:(y+h), x:(x+w)] += (binarray * (count))
+
+    print(labels)
+    print(labels.min(), labels.max())
+    return labels
+
+
+# def add_group_metadata(zarr_root, image, resolutions=1):
+
+#     image_data = {
+#         'id': 1,
+#         'channels': [channelMarshal(c) for c in image.getChannels()],
+#         'rdefs': {'model': (image.isGreyscaleRenderingModel() and
+#                                      'greyscale' or 'color'),
+#                            'defaultZ': image._re.getDefaultZ(),
+#                            'defaultT': image._re.getDefaultT()}
+#     }
+#     multiscales = [{
+#         "version": "0.1",
+#         "datasets": [{'path': str(r)} for r in range(resolutions)],
+#     }]
+#     zarr_root.attrs["multiscales"] = multiscales
+#     zarr_root.attrs["omero"] = image_data


### PR DESCRIPTION
Work in progress (need to move Image export to a new sub command etc)

First implementation of exporting OMERO Masks as zarr file:
To test this branch:

```
$ omero zarr masks Image:6001240
Previous session expired for public on idr.openmicroscopy.org:4064
Server: [idr.openmicroscopy.org:4064]
Username: [public]
Password:

Created 6001240_masks.zarr
```
Then:
```
$ napari 6001240_masks.zarr
```

<img width="876" alt="Screenshot 2020-06-22 at 23 12 11" src="https://user-images.githubusercontent.com/900055/85340387-ea4e6600-b4dd-11ea-9d15-05b60fdb47e1.png">

cc @joshmoore @manics